### PR TITLE
security: GitHub hardening — CODEOWNERS + deploy workflow removal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from security-aware team for workflow changes
+.github/workflows/ @zigchain/admins
+.github/ @zigchain/admins


### PR DESCRIPTION
## Summary

- Add/update CODEOWNERS to require admin review for `.github/` changes

